### PR TITLE
Add a second argument to unsubscribe, keeps backwards compatibility

### DIFF
--- a/minpubsub.src.js
+++ b/minpubsub.src.js
@@ -56,7 +56,7 @@
 		return [topic, callback]; // Array
 	};
 
-	d.unsubscribe = function(/* Array */ handle){
+	d.unsubscribe = function(/* Array */ handle, /* Function? */ callback){
 		// summary:
 		//		Disconnect a subscribed function for a topic.
 		// handle: Array
@@ -65,8 +65,8 @@
 		//		var handle = subscribe("/some/topic", function(){});
 		//		unsubscribe(handle);
 		
-		var subs = cache[handle[0]],
-			callback = handle[1],
+		var subs = cache[callback ? handle : handle[0]],
+			callback = callback || handle[1],
 			len = subs ? subs.length : 0;
 		
 		while(len--){

--- a/unit-tests.htm
+++ b/unit-tests.htm
@@ -93,6 +93,13 @@ YUI({ filter: 'raw' }).use("node", "console", "test" , function (Y) {
 			window.unsubscribe(["/some/topic", this.func]);
 
 			Assert.areNotEqual(this.func, c_["/some/topic"][0]);
+		},
+		testRemoveSubTwoArgs : function () {
+			var Assert = Y.Assert;
+
+			window.unsubscribe("/some/topic", this.func);
+
+			Assert.areNotEqual(this.func, c_["/some/topic"][0]);
 		}
 	});
 	


### PR DESCRIPTION
I'm trying a few changes on MinPubSub you might like.
This one allows unsubscribe without creating an array or keeping a handler.
I've only changed the src file, and not the minified version, but I've ran the tests with it.
