### PR TITLE
Add a new once() function that subscribe a callback only once

### DIFF
--- a/minpubsub.src.js
+++ b/minpubsub.src.js
@@ -6,74 +6,101 @@
 
 (function(d){
 
-	// the topic/subscription hash
-	var cache = d.c_ || {}; //check for "c_" cache for unit testing
-	
-	d.publish = function(/* String */ topic, /* Array? */ args){
-		// summary: 
-		//		Publish some data on a named topic.
-		// topic: String
-		//		The channel to publish on
-		// args: Array?
-		//		The data to publish. Each array item is converted into an ordered
-		//		arguments on the subscribed functions. 
-		//
-		// example:
-		//		Publish stuff on '/some/topic'. Anything subscribed will be called
-		//		with a function signature like: function(a,b,c){ ... }
-		//
-		//		publish("/some/topic", ["a","b","c"]);
-		
-		var subs = cache[topic],
-			len = subs ? subs.length : 0;
+  // the topic/subscription hash
+  var cache = d.c_ || {}; //check for "c_" cache for unit testing
 
-		//can change loop or reverse array if the order matters
-		while(len--){
-			subs[len].apply(d, args || []);
-		}
-	};
+  d.publish = function(/* String */ topic, /* Array? */ args){
+    // summary:
+    //    Publish some data on a named topic.
+    // topic: String
+    //    The channel to publish on
+    // args: Array?
+    //    The data to publish. Each array item is converted into an ordered
+    //    arguments on the subscribed functions.
+    //
+    // example:
+    //    Publish stuff on '/some/topic'. Anything subscribed will be called
+    //    with a function signature like: function(a,b,c){ ... }
+    //
+    //    publish("/some/topic", ["a","b","c"]);
 
-	d.subscribe = function(/* String */ topic, /* Function */ callback){
-		// summary:
-		//		Register a callback on a named topic.
-		// topic: String
-		//		The channel to subscribe to
-		// callback: Function
-		//		The handler event. Anytime something is publish'ed on a 
-		//		subscribed channel, the callback will be called with the
-		//		published array as ordered arguments.
-		//
-		// returns: Array
-		//		A handle which can be used to unsubscribe this particular subscription.
-		//	
-		// example:
-		//		subscribe("/some/topic", function(a, b, c){ /* handle data */ });
+    var subs = cache[topic],
+      len = subs ? subs.length : 0;
 
-		if(!cache[topic]){
-			cache[topic] = [];
-		}
-		cache[topic].push(callback);
-		return [topic, callback]; // Array
-	};
+    //can change loop or reverse array if the order matters
+    while(len--){
+      subs[len].apply(d, args || []);
+    }
+  };
 
-	d.unsubscribe = function(/* Array */ handle){
-		// summary:
-		//		Disconnect a subscribed function for a topic.
-		// handle: Array
-		//		The return value from a subscribe call.
-		// example:
-		//		var handle = subscribe("/some/topic", function(){});
-		//		unsubscribe(handle);
-		
-		var subs = cache[handle[0]],
-			callback = handle[1],
-			len = subs ? subs.length : 0;
-		
-		while(len--){
-			if(subs[len] === callback){
-				subs.splice(len, 1);
-			}
-		}
-	};
+  d.subscribe = function(/* String */ topic, /* Function */ callback){
+    // summary:
+    //    Register a callback on a named topic.
+    // topic: String
+    //    The channel to subscribe to
+    // callback: Function
+    //    The handler event. Anytime something is publish'ed on a
+    //    subscribed channel, the callback will be called with the
+    //    published array as ordered arguments.
+    //
+    // returns: Array
+    //    A handle which can be used to unsubscribe this particular subscription.
+    //
+    // example:
+    //    subscribe("/some/topic", function(a, b, c){ /* handle data */ });
+
+    if(!cache[topic]){
+      cache[topic] = [];
+    }
+    cache[topic].push(callback);
+    return [topic, callback]; // Array
+  };
+
+  d.once = function(/* String */ topic, /* Function */ callback){
+    // summary:
+    //    Register a callback that runs only once on a named topic.
+    // topic: String
+    //    The channel to subscribe to
+    // callback: Function
+    //    The handler event. The first something is publish'ed on a
+    //    subscribed channel, the callback will be called with the
+    //    published array as ordered arguments.
+    //
+    // returns: Array
+    //    A handle which can be used to unsubscribe this particular subscription.
+    //
+    // example:
+    //    subscribe("/some/topic", function(a, b, c){ /* handle data */ });
+
+    if(!cache[topic]){
+      cache[topic] = [];
+    }
+    var f = function() {
+      d.unsubscribe([topic, f]);
+      callback.apply(d, arguments);
+    }
+    cache[topic].push(f);
+    return [topic, f]; // Array
+  };
+
+  d.unsubscribe = function(/* Array */ handle){
+    // summary:
+    //    Disconnect a subscribed function for a topic.
+    // handle: Array
+    //    The return value from a subscribe call.
+    // example:
+    //    var handle = subscribe("/some/topic", function(){});
+    //    unsubscribe(handle);
+
+    var subs = cache[handle[0]],
+      callback = handle[1],
+      len = subs ? subs.length : 0;
+
+    while(len--){
+      if(subs[len] === callback){
+        subs.splice(len, 1);
+      }
+    }
+  };
 
 })(this);

--- a/unit-tests.htm
+++ b/unit-tests.htm
@@ -75,6 +75,29 @@ YUI({ filter: 'raw' }).use("node", "console", "test" , function (Y) {
 		}
 	});
 
+	Y.pubsub.test.OnceTestCase = new Y.Test.Case({
+		name : "Subscribe Once Tests",
+
+		tearDown : function () {
+			delete c_["/some/topic"];
+		},
+
+		//tests
+		testAddSub : function () {
+			var Assert = Y.Assert,
+				count = 0,
+			func = function(val){ console.log(val); count += val; },
+				handle = window.once("/some/topic", func);
+
+			Assert.areEqual(handle[1], c_["/some/topic"][0]);
+			window.publish("/some/topic", [3]);
+			Assert.areEqual(3, count);
+			window.publish("/some/topic", [5]);
+			Assert.areEqual(3, count);
+			Assert.areNotEqual(handle[1], c_["/some/topic"][0]);
+		}
+	});
+
 	Y.pubsub.test.UnsubscribeTestCase = new Y.Test.Case({
 		name : "Unsubscribe Tests",
 		
@@ -99,6 +122,7 @@ YUI({ filter: 'raw' }).use("node", "console", "test" , function (Y) {
 	Y.pubsub.test.PubSubSuite = new Y.Test.Suite("MinPubSub Suite");
 	Y.pubsub.test.PubSubSuite.add(Y.pubsub.test.PublishTestCase);
 	Y.pubsub.test.PubSubSuite.add(Y.pubsub.test.SubscribeTestCase);
+	Y.pubsub.test.PubSubSuite.add(Y.pubsub.test.OnceTestCase);
 	Y.pubsub.test.PubSubSuite.add(Y.pubsub.test.UnsubscribeTestCase);
 
 	var r = new Y.Console({


### PR DESCRIPTION
I'm trying a few changes on MinPubSub you might like.
This one allows a "subscribe once" callback, which is only ran the first time someone publishes to a topic.
I've only changed the src file, and not the minified version, but I've ran the tests with it.
