### PR TITLE
Remove array argument from publish

### DIFF
--- a/minpubsub.src.js
+++ b/minpubsub.src.js
@@ -9,27 +9,27 @@
 	// the topic/subscription hash
 	var cache = d.c_ || {}; //check for "c_" cache for unit testing
 	
-	d.publish = function(/* String */ topic, /* Array? */ args){
+	d.publish = function(/* String */ topic /*, Args... */ ){
 		// summary: 
 		//		Publish some data on a named topic.
 		// topic: String
 		//		The channel to publish on
-		// args: Array?
-		//		The data to publish. Each array item is converted into an ordered
-		//		arguments on the subscribed functions. 
+		// Args....
+		//		The data to publish. Each remaining argument is passed to the
+    //    subscribed functions.
 		//
 		// example:
 		//		Publish stuff on '/some/topic'. Anything subscribed will be called
 		//		with a function signature like: function(a,b,c){ ... }
 		//
-		//		publish("/some/topic", ["a","b","c"]);
+		//		publish("/some/topic", "a", "b", "c");
 		
 		var subs = cache[topic],
 			len = subs ? subs.length : 0;
 
 		//can change loop or reverse array if the order matters
 		while(len--){
-			subs[len].apply(d, args || []);
+			subs[len].apply(d, Array.prototype.slice.call(arguments, 1));
 		}
 	};
 

--- a/unit-tests.htm
+++ b/unit-tests.htm
@@ -30,8 +30,8 @@ YUI({ filter: 'raw' }).use("node", "console", "test" , function (Y) {
 			me.count = 0;
 
 			c_["/some/topic"] = [
-				function (msg) {
-					me.count++;
+				function (val) {
+					me.count += val;
 				}
 			];
 		},
@@ -44,9 +44,9 @@ YUI({ filter: 'raw' }).use("node", "console", "test" , function (Y) {
 		testHasSub : function () {
 			var Assert = Y.Assert;
 		
-			window.publish("/some/topic");
+			window.publish("/some/topic", 3);
 
-			Assert.areEqual(1, this.count);   
+			Assert.areEqual(3, this.count);
 		},
 		testNoSub : function () {
 			var Assert = Y.Assert;


### PR DESCRIPTION
I'm trying a few changes on MinPubSub you might like.
This one breaks external behavior.
It removes the args argument from publish, passing all remaining arguments to publish() to the listeners.
I've only changed the src file, and not the minified version, but I've ran the tests with it.
