### PR TITLE
Tree Subscriptions

### DIFF
--- a/minpubsub.src.js
+++ b/minpubsub.src.js
@@ -10,9 +10,8 @@
 	var cache = d.c_ || {}; //check for "c_" cache for unit testing
 	
 	var publishTopic = function(/* String */ topic, /* String */ originalTopic, /* Array? */ args) {
-	    console.log('publishing', topic);
 		var subs = cache[topic],
-			len = subs ? subs.length : 0
+			len = subs ? subs.length : 0,
 			obj = {
 			    originalTopic: originalTopic /*,
 			    subTopic: ..... */
@@ -22,7 +21,7 @@
 		while(len--){
 			subs[len].apply(obj, args || []);
 		}
-	}
+	};
 	
 	d.publish = function(/* String */ topic, /* Array? */ args){
 	    var currentTopic;
@@ -39,6 +38,11 @@
 		//		with a function signature like: function(a,b,c){ ... }
 		//
 		//		publish("/some/topic", ["a","b","c"]);
+		//		
+		//		Anything subscribed on a "parent" topic (i.e. "/some") will also
+		//		be called.  Callbacks can use "this.originalTopic" to get a
+		//		reference to the actual topic that was called
+		//		
 		currentTopic = topic;
 		while ( currentTopic.length > 0 ) {
 		    publishTopic(currentTopic, topic, args);
@@ -62,6 +66,9 @@
 		//	
 		// example:
 		//		subscribe("/some/topic", function(a, b, c){ /* handle data */ });
+		//		
+		//		subscribe("/some", function(a, b, c) { console.log(this.originalTopic); } );
+		
 
 		if(!cache[topic]){
 			cache[topic] = [];
@@ -80,8 +87,9 @@
 		//		unsubscribe(handle);
 		
 		var subs = cache[callback ? handle : handle[0]],
-			callback = callback || handle[1],
 			len = subs ? subs.length : 0;
+		
+		callback = callback || handle[1];
 		
 		while(len--){
 			if(subs[len] === callback){

--- a/unit-tests.htm
+++ b/unit-tests.htm
@@ -111,6 +111,32 @@ YUI({ filter: 'raw' }).use("node", "console", "test" , function (Y) {
 			window.publish("/some/path");
 			
 			Assert.areEqual("/some/path", originalTopic);
+		},
+		
+		testPublishAnySlashes : function() {
+			var Assert = Y.Assert,
+			    counter = 0,
+				func = function(){ counter++; };
+		
+			window.subscribe("somepath", func);
+			
+			window.publish("somepath");
+			
+			Assert.areEqual(1, counter);
+		},
+		
+		testPublishWithoutLeadingSlash : function() {
+			var Assert = Y.Assert,
+			    counter = 0,
+				func = function(){ counter++; };
+		
+			window.subscribe("some", func);
+			window.subscribe("some/path", func);
+			
+			window.publish("some/path");
+			window.publish("bogus/path");
+			
+			Assert.areEqual(2, counter);
 		}
 	});
 


### PR DESCRIPTION
Hi Daniel,

not sure if this is the kind of thing you'd be interested, but something I've often thought was missing from pub/sub implementations was the ability to subscribe to a _group_ of topics, like so:

``` javascript
subscribe('/server/success', function(req, rsp) {} );
subscribe('/server/start', function(req) {} );
subscribe('/server', function() { console.log('possibly do some logging'); });

publish('/server/start', [req]);
publish('/server/success', [req, rsp]);
publish('/server/error', [req, rsp]); // note the last subscription also picks this up!
```

Since subscriptions would no longer be identical to the published event names, but might be a subset, the next requirement is some reference to what was originally published.  I think a reasonable way of achieving this is to create a custom scope which has "this.originalTopic" set, like so:

``` javascript
subscribe('/server', function() {
  switch (this.originalTopic) {
    case '/server/start' :
      showThrobber();
    case '/server/success' :
      hideThrobber();
    case '/server/error' :
      showErrorMessage();
  }
});
```

I've had a go at implementing this and written a few tests.

This pull request is really just a place for any feedback you might, I think MinPubSub is pretty lean and mean and doesn't necessarily need this feature :)

I wrote this because we were thinking about adding a generic set of "/sound/*" topics to an application we're building, but as it turns out we've moved away from the idea and will be using MinPubSub in a more traditional way.  Once I'd thought about the feature though, I more or less had to scratch the itch and implement it!

Thanks for listening!

Pete
